### PR TITLE
Fix for hue and small hashes

### DIFF
--- a/identicon.js
+++ b/identicon.js
@@ -32,15 +32,16 @@
             // light-grey background
             var bg      = image.color(240, 240, 240);
 
-            // foreground is last 7 chars as hue at 50% saturation, 70% brightness
-            var rgb     = this.hsl2rgb(parseInt(hash.substr(-7), 16) / 0xfffffff, .5, .7),
+            // foreground is first 7 chars as hue at 50% saturation, 70% brightness which generates 456 unique colors
+            var rgb     = this.hsl2rgb(parseInt(hash.substr(0, 7), 16) / 0x10000000, .5, .7),
                 fg      = image.color(rgb[0] * 255, rgb[1] * 255, rgb[2] * 255);
 
-            // the first 15 characters of the hash control the pixels (even/odd)
+            // the last 4 characters of the hash (the 15 least significant bits) control the pixels
             // they are drawn down the middle first, then mirrored outwards
-            var i, color;
+            var i, color, bits = parseInt(hash.substr(-4), 16);
             for (i = 0; i < 15; i++) {
-                color = parseInt(hash.charAt(i), 16) % 2 ? bg : fg;
+                color = bits % 2 ? bg : fg;
+                bits >>= 1;
                 if (i < 5) {
                     this.rectangle(2 * cell + margin, i * cell + margin, cell, cell, color, image);
                 } else if (i < 10) {


### PR DESCRIPTION
Hue of 0% is the same color as hue of 100%. Anyways hue is usually represented as an angle [0° to 360°) because it is cyclical or in this case a percentage of a circle [0%, 100%).

Using the first 7 characters and last 4 characters of the hash because if a short hash is given then the last 7 characters run into the first 15 characters. Which causes the color and pixels to be related. Having hue first limits the effect of the overlap with really small hashes.

There should probably be a warning if the hash is not hex or is less than 11 characters (bare minimum is 7 characters).
