### PR TITLE
added bower, npm packages and semver release automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.idea/

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,20 @@
+{
+  "name": "identicon.js",
+  "main": [
+    "pnglib.js",
+    "identicon.js"
+  ],
+  "version": "1.0.0",
+  "homepage": "https://github.com/stewartlord/identicon.js",
+  "authors": [
+    "stewardlord"
+  ],
+  "description": "GitHub-style identicons in JS with no server-side processing.",
+  "moduleType": [
+    "globals"
+  ],
+  "keywords": [
+    "identicon"
+  ],
+  "license": "BSD"
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,46 @@
+//------------ user for publishing
+gulp.task('bump-patch-version', function () {
+    return gulp.src(['./bower.json', './package.json'])
+        .pipe(bump({type: "patch"}).on('error', gutil.log))
+        .pipe(gulp.dest('./'));
+});
+
+gulp.task('commit-changes', function () {
+    return gulp.src('.')
+        .pipe(git.commit('Bumped version number'));
+});
+
+gulp.task('push-changes', function (cb) {
+    git.push('origin', 'master', cb);
+});
+
+gulp.task('create-new-tag', function (cb) {
+    var version = getPackageJsonVersion();
+    git.tag(version, 'Created Tag for version: ' + version, function (error) {
+        if (error) {
+            return cb(error);
+        }
+        git.push('origin', 'master', {args: '--tags'}, cb);
+    });
+
+    function getPackageJsonVersion () {
+        //We parse the json file instead of using require because require caches multiple calls so the version number won't be updated
+        return JSON.parse(fs.readFileSync('./package.json', 'utf8')).version;
+    }
+});
+
+gulp.task('release', function (callback) {
+    runSequence(
+        'bump-patch-version',
+        'commit-changes',
+        'push-changes',
+        'create-new-tag',
+        function (error) {
+            if (error) {
+                console.log(error.message);
+            } else {
+                console.log('RELEASE FINISHED SUCCESSFULLY');
+            }
+            callback(error);
+        });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "identicon.js",
+  "version": "1.0.0",
+  "description": "GitHub-style identicons in JS with no server-side processing.",
+  "main": "identicon.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stewartlord/identicon.js"
+  },
+  "keywords": [
+    "identicon"
+  ],
+  "author": "stewardlord",
+  "license": "BSD",
+  "bugs": {
+    "url": "https://github.com/stewartlord/identicon.js/issues"
+  },
+  "homepage": "https://github.com/stewartlord/identicon.js",
+  "devDependencies": {
+    "gulp": "^3.9.0"
+  }
+}


### PR DESCRIPTION
I've registered this repo with bower. This PR adds bower.json

For npm i've added package.json but you would probably want to publish this package yourself to have your name there :)
Steps are explained here: https://gist.github.com/coolaj86/1318304 

Also i'm also adding gulpfile. It contains a 'release' task to automatically bump version and mark repo with proper semver tag. 

The way you use it is:

`npm install` // just first time 
`gulp release` //anytime you want to publish new verion

This will bump a patch version defined in package.json and bower.json, commit, push and then create tag and push tags to origin.

Please let me know if you have any suggetions.
Thanks,
Lukasz

fixes #2 
