### PR TITLE
Change octal literals to hex to prevent espree errors.

### DIFF
--- a/pnglib.js
+++ b/pnglib.js
@@ -200,7 +200,7 @@
 			crc32(this.buffer, this.iend_offs, this.iend_size);
 
 			// convert PNG to string
-			return "\211PNG\r\n\032\n"+this.buffer.join('');
+			return "\x89PNG\r\n\x1A\n"+this.buffer.join('');
 		}
 	}
 


### PR DESCRIPTION
When parsing the bundled version of pnglib for minification, espree will throw:

```
Error: Line 203: Octal literals are not allowed in strict mode.
```

I changed the octal literals to hex literals to avoid this.
