### PR TITLE
Fixed opacity calculation in `color`

### DIFF
--- a/identicon.js
+++ b/identicon.js
@@ -165,7 +165,7 @@
 
         color: function(r, g, b, a){
             var values = [r, g, b].map(Math.round);
-            values.push((a >= 0) && (a <= 255) ? a/255 : 1)
+            values.push((a >= 0) && (a <= 255) ? a/255 : 1);
             return 'rgba(' + values.join(',') + ')';
         },
 

--- a/identicon.js
+++ b/identicon.js
@@ -164,8 +164,8 @@
         rectangles: null,
 
         color: function(r, g, b, a){
-            var values = [r, g, b, a ? a/255 : 1].map(Math.round);
-            return 'rgba(' + values.join(',') + ')';
+            var values = [r, g, b].map(Math.round);
+            return 'rgba(' + values.join(',') + ',' + (((a >= 0) && (a <= 255)) ? a/255 : 1) + ')';
         },
 
         getDump: function(){

--- a/identicon.js
+++ b/identicon.js
@@ -165,7 +165,8 @@
 
         color: function(r, g, b, a){
             var values = [r, g, b].map(Math.round);
-            return 'rgba(' + values.join(',') + ',' + (((a >= 0) && (a <= 255)) ? a/255 : 1) + ')';
+            values.push((a >= 0) && (a <= 255) ? a/255 : 1)
+            return 'rgba(' + values.join(',') + ')';
         },
 
         getDump: function(){


### PR DESCRIPTION
The original alpha calculation in `color` was applied _before_ `Math.round()` and didn't handle an input value of `0` (...which evaluates to logical false, giving a value of `1` -- very confusing!). Really great library though :)