### PR TITLE
If btoa() is unavailable use Buffer instead.

### DIFF
--- a/identicon.js
+++ b/identicon.js
@@ -187,6 +187,9 @@
         },
 
         getBase64: function(){
+            if (!btoa) {
+                let btoa = (str) => new Buffer(str.toString(), 'binary').toString('base64');
+            }
             return btoa(this.getDump());
         }
     };

--- a/identicon.js
+++ b/identicon.js
@@ -187,10 +187,13 @@
         },
 
         getBase64: function(){
-            if (!btoa) {
-                let btoa = (str) => new Buffer(str.toString(), 'binary').toString('base64');
+            if (btoa) {
+                return btoa(this.getDump());
+            } else if (Buffer) {
+                return new Buffer(this.getDump(), 'binary').toString('base64');
+            } else {
+                throw 'Cannot generate base64 output';
             }
-            return btoa(this.getDump());
         }
     };
 


### PR DESCRIPTION
Fixes #42 