### PR TITLE
Fix exception "btoa is not defined"

### DIFF
--- a/identicon.js
+++ b/identicon.js
@@ -187,7 +187,7 @@
         },
 
         getBase64: function(){
-            if (typeof btoa !== 'undefined') {
+            if ('function' === typeof btoa) {
                 return btoa(this.getDump());
             } else if (Buffer) {
                 return new Buffer(this.getDump(), 'binary').toString('base64');

--- a/identicon.js
+++ b/identicon.js
@@ -187,7 +187,7 @@
         },
 
         getBase64: function(){
-            if (btoa) {
+            if (typeof btoa !== 'undefined') {
                 return btoa(this.getDump());
             } else if (Buffer) {
                 return new Buffer(this.getDump(), 'binary').toString('base64');


### PR DESCRIPTION
btoa is not defined
    at Svg.getBase64 (/Users/ars/src/***/node_modules/identicon.js/identicon.js:190:13)
    at Identicon.toString (/Users/ars/src/***/node_modules/identicon.js/identicon.js:133:38)
    at Object.generateIcon (/Users/ars/src/***/backend/lib/helpers.js:88:46)